### PR TITLE
Fixed used override version

### DIFF
--- a/src/main/java/org/deeplearning4j/iris/IrisExample.java
+++ b/src/main/java/org/deeplearning4j/iris/IrisExample.java
@@ -48,7 +48,7 @@ public class IrisExample {
                 .learningRate(1e-1f)
                 .nIn(4).nOut(3).list(2)
                 .hiddenLayerSizes(new int[]{3})
-                .override(new ClassifierOverride(1)).build();
+                .override(1, new ClassifierOverride(1)).build();
 
 
         MultiLayerNetwork d = new MultiLayerNetwork(conf);


### PR DESCRIPTION
Used proper override version, to remove warning log: o.d.n.m.MultiLayerNetwork - Output layer not instance of output layer returning. (#258 on deeplearning4j)