### PR TITLE
Update some examples to new API

### DIFF
--- a/src/main/java/org/deeplearning4j/deepbelief/DBNCreateDataExample.java
+++ b/src/main/java/org/deeplearning4j/deepbelief/DBNCreateDataExample.java
@@ -2,14 +2,11 @@ package org.deeplearning4j.deepbelief;
 
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
-import org.deeplearning4j.nn.conf.distribution.UniformDistribution;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.layers.RBM;
 import org.deeplearning4j.eval.Evaluation;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
-import org.deeplearning4j.nn.conf.override.ClassifierOverride;
-import org.deeplearning4j.nn.layers.factory.LayerFactories;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.nn.weights.WeightInit;
@@ -23,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 
 /**

--- a/src/main/java/org/deeplearning4j/deepbelief/DBNIrisExample.java
+++ b/src/main/java/org/deeplearning4j/deepbelief/DBNIrisExample.java
@@ -8,21 +8,13 @@ import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.Updater;
-import org.deeplearning4j.nn.conf.distribution.UniformDistribution;
-import org.deeplearning4j.nn.conf.layers.Layer;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.layers.RBM;
-import org.deeplearning4j.nn.conf.override.ClassifierOverride;
-import org.deeplearning4j.nn.conf.override.ConfOverride;
-import org.deeplearning4j.nn.conf.rng.DefaultRandom;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
-import org.deeplearning4j.plot.iterationlistener.GradientPlotterIterationListener;
-import org.deeplearning4j.plot.iterationlistener.LossPlotterIterationListener;
-import org.deeplearning4j.plot.iterationlistener.NeuralNetPlotterIterationListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.SplitTestAndTrain;
@@ -34,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
-import java.util.Collections;
 
 
 /**

--- a/src/main/java/org/deeplearning4j/deepbelief/DBNLFWExample.java
+++ b/src/main/java/org/deeplearning4j/deepbelief/DBNLFWExample.java
@@ -5,22 +5,22 @@ import org.deeplearning4j.datasets.fetchers.LFWDataFetcher;
 import org.deeplearning4j.datasets.iterator.DataSetIterator;
 import org.deeplearning4j.datasets.iterator.impl.LFWDataSetIterator;
 import org.deeplearning4j.eval.Evaluation;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.layers.RBM;
-import org.deeplearning4j.nn.conf.override.ClassifierOverride;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
-import org.nd4j.linalg.lossfunctions.LossFunctions;
+import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 
 /**
@@ -45,19 +45,19 @@ public class DBNLFWExample {
 
         log.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
-                .layer(new RBM())
-                .nIn(dataIter.inputColumns())
-                .nOut(dataIter.totalOutcomes())
                 .hiddenUnit(RBM.HiddenUnit.RECTIFIED)
                 .visibleUnit(RBM.VisibleUnit.GAUSSIAN)
                 .seed(seed)
                 .weightInit(WeightInit.XAVIER)
-                .lossFunction(LossFunctions.LossFunction.RMSE_XENT)
                 .constrainGradientToUnitNorm(true)
-                .learningRate(1e-3)
+                .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
                 .list(4)
-                .hiddenLayerSizes(600, 250, 200)
-                .override(3,new ClassifierOverride())
+                .layer(0, new RBM.Builder().nIn(dataIter.inputColumns()).nOut(600).build())
+                .layer(1, new RBM.Builder().nIn(600).nOut(250).build())
+                .layer(2, new RBM.Builder().nIn(250).nOut(200).build())
+                .layer(3, new OutputLayer.Builder(LossFunction.RMSE_XENT).activation("softmax")
+                	.nIn(200).nOut(dataIter.totalOutcomes()).build())
+            	.pretrain(true).backward(false)
                 .build();
 
         MultiLayerNetwork model = new MultiLayerNetwork(conf);

--- a/src/main/java/org/deeplearning4j/rbm/RBMCreateDataExample.java
+++ b/src/main/java/org/deeplearning4j/rbm/RBMCreateDataExample.java
@@ -9,7 +9,6 @@ import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
-import org.deeplearning4j.plot.NeuralNetPlotter;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;

--- a/src/main/java/org/deeplearning4j/recurrent/RecurrentLSTMMnistExample.java
+++ b/src/main/java/org/deeplearning4j/recurrent/RecurrentLSTMMnistExample.java
@@ -7,11 +7,8 @@ import org.deeplearning4j.nn.conf.layers.LSTM;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.layers.factory.LayerFactories;
 //import org.deeplearning4j.nn.layers.recurrent.LSTM;
-import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
-import org.deeplearning4j.plot.NeuralNetPlotter;
-import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
 import org.slf4j.Logger;
@@ -19,7 +16,6 @@ import org.slf4j.LoggerFactory;
 
 
 import java.util.Arrays;
-import java.util.Collections;
 
 /**
  * Created by willow on 5/11/15.


### PR DESCRIPTION
I've done a a basic pass on some examples in order to update them to the new config api. Known issues and notes:
- DBNFullMnistExample/DBNSmallMnistExample/DBNSingleLayerExample: Scores are currently NaN. Not sure why, but maybe a hyperparameter issue (Iris and LFW DBN examples have valid scores)
- DBNLFWExample: Scores are OK (and decreasing for first few iterations) but haven't run full way through
- MLPBackpropIrisExample: Scores increase vs. iteration, becoming NaN. Suspect this is due to partial implementation of backprop changes in current version of dl4j master - i.e., BaseLayer.update() doing params + gradient rather than params - gradient (and backprop not properly using optimizers yet)
- RBMIrisExample: tensorAlongDimension throwing "Exception in thread "main" java.lang.ArithmeticException: / by zero"
- All other examples (CNN, Recursive, Glove): not checked (I'm not familiar enough with these to do a proper pass/debug).